### PR TITLE
Notification when Modmailed user links account

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -178,7 +178,19 @@ const assignTftVerifiedRole = async (discordUserId) => {
   }
   if (guildMember) {
     await guildMember.roles.add(LINKED_TFT_POE_ROLE_ID);
+    await notifyModmailLink(discordUserId);
   }
+}
+
+const notifyModmailLink = async (discordUserId) => {
+  const guild = await client.guilds.fetch(TFT_SERVER_ID, true);
+  const userChannel = await guild.channels.cache.find(channel => channel.type == 0 && channel.parentId && channel.parentId == MODMAIL_CATEGORY && channel.topic && channel.topic.search(discordUserId) != -1);
+  const infoEmbed = {
+      "title": `ℹ️ User Linked ℹ️`,
+      "description": `The user in this modmail has linked a PoE account.`,
+      "color": 0xff448e
+  }
+  await userChannel.send({ embeds: [infoEmbed] });
 }
 
 const buildAuthorizeURL = (state) => {


### PR DESCRIPTION
When a user with an active modmail links an account, this will drop a notification in the modmail channel:

![image](https://user-images.githubusercontent.com/22421329/208208594-3efbbdf9-06a8-4c90-bb0a-ad90121d03cf.png)
