### PR TITLE
Put back what the merge conflict threw out

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -184,7 +184,8 @@ const assignTftVerifiedRole = async (discordUserId) => {
 
 const notifyModmailLink = async (discordUserId) => {
   const guild = await client.guilds.fetch(TFT_SERVER_ID, true);
-  const userChannel = await guild.channels.cache.find(channel => channel.type == 0 && channel.parentId && channel.parentId == MODMAIL_CATEGORY && channel.topic && channel.topic.search(discordUserId) != -1);
+  const channels = await guild.channels.fetch();
+  let userChannel = channels.find(channel => channel.type == 0 && channel.parentId && channel.parentId == MODMAIL_CATEGORY && channel.topic && channel.topic.search(discordUserId) != -1);
   const poeAccount = await getPoeTftStateLinkByDiscordId(discordUserId);
   const infoEmbed = {
       "title": `ℹ️ User Linked ℹ️`,


### PR DESCRIPTION
Merge conflict threw out Glu's commit, which left us unable to acquire a valid userChannel. Don't know how that happened but I blame Linus Torvalds.